### PR TITLE
Clojure 1.2 release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (defproject com.draines/postal "1.4.0-SNAPSHOT"
   :resources-path "etc"
   :repositories {"java.net" "http://download.java.net/maven/2"}
-  :dependencies [[org.clojure/clojure "1.2.0-master-SNAPSHOT"]
-                 [org.clojure/clojure-contrib "1.2.0-SNAPSHOT"]
+  :dependencies [[org.clojure/clojure "1.2.0"]
+                 [org.clojure/clojure-contrib "1.2.0"]
                  [javax.mail/mail "1.4.4-SNAPSHOT"
                   :exclusions [javax.activation/activation]]]
   :dev-dependencies [[swank-clojure "1.2.1"]]


### PR DESCRIPTION
Since there's now a release of 1.2.0 you may want to remove the SNAPSHOTS, or go ahead and do a 1.4.0 release of postal?
