### PR TITLE
port was set to nil when sending via smtp 

### DIFF
--- a/src/postal/smtp.clj
+++ b/src/postal/smtp.clj
@@ -17,7 +17,8 @@
                    sender ssl] :or {host "localhost"}}
            auth-map
            port (if (not port)
-                  (if ssl 465 25))
+                  (if ssl 465 25)
+                  port)
            protocol (if ssl "smtps" "smtp")
            session (doto (Session/getInstance (make-props sender auth-map))
                      (.setDebug false))]


### PR DESCRIPTION
When a port was manually supplied with ":port", the if form set it to nil as it was missing an else form.
