### PR TITLE
Add UTF-8 to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ support (or suppress) HTML-mails:
 #### UTF-8
 
 Postal uses JavaMail under the covers, which defaults to charset
-"us-ascii". To set the charset, set the :type, like `"text/html; charset=utf-8"`
+`us-ascii`. To set the charset, set the `:type`, like `"text/html; charset=utf-8"`
 
 #### Stress-testing
 


### PR DESCRIPTION
This adds a section on how to send email in UTF-8. 

Sorry about the formatting on the first commit, I think my editor strips trailing whitespace from newlines. 
