### PR TITLE
Async Support for Postal?

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,8 @@
   :repositories {"java.net" "http://download.java.net/maven/2"}
   :dependencies [[commons-codec "1.7"]
                  [javax.mail/mail "1.4.4"
-                  :exclusions [javax.activation/activation]]]
+                  :exclusions [javax.activation/activation]]
+                 [org.clojure/core.async "0.1.256.0-1bf8cf-alpha"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}})


### PR DESCRIPTION
@drewr, what do you think about using core.async to make postal async? I'm imagining that send-mail would return a channel, rather than blocking.

I started working on this, thinking that `JavaMail` was actually async (based on the existence of the `TransportListener`; looks like that's not the case, unless I'm missing some obvious way to have `transport.send` return immediately.

This pull request starts the feature off. This is mostly to start discussion.