### PR TITLE
lookup sendmail command only once

### DIFF
--- a/src/postal/sendmail.clj
+++ b/src/postal/sendmail.clj
@@ -55,7 +55,7 @@
      :error e
      :message message}))
 
-(defn sendmail-find []
+(def sendmail
   (if-let [SENDMAIL (System/getenv "SENDMAIL")]
     SENDMAIL
     (first (filter #(.isFile (java.io.File. ^String %)) sendmails))))
@@ -66,7 +66,7 @@
 (defn sendmail-send [msg]
   (let [mail (sanitize (message->str msg))
         cmd (concat
-             [(sendmail-find) (format "-f %s" (sender msg))]
+             [sendmail (format "-f %s" (sender msg))]
              (recipients msg))
         pb (ProcessBuilder. cmd)
         p (.start pb)


### PR DESCRIPTION
Don't loop through all sendmail variants, find only once. Also it would be nice to give a warning if sendmail not found but I don't know how to do it better, (prn) looks doesn't good to me.
If sendmail not installed NPE from ProcessBuilder is thrown, see http://pastebin.com/C8fcXwA2
