### PR TITLE
Enabling of sasl

### DIFF
--- a/src/postal/support.clj
+++ b/src/postal/support.clj
@@ -31,11 +31,12 @@
   `(when ~condition
      (doto ~arg ~@body)))
 
-(defn make-props [sender {:keys [host port user tls]}]
+(defn make-props [sender {:keys [host port user tls sasl]}]
   (doto (Properties.)
     (.put "mail.smtp.host" (or host "not.provided"))
     (.put "mail.smtp.port" (or port "25"))
     (.put "mail.smtp.auth" (if user "true" "false"))
+    (.put "mail.smtp.sasl.enable" (if (= false sasl) "false" "true"))
     (do-when sender (.put "mail.smtp.from" sender))
     (do-when user (.put "mail.smtp.user" user))
     (do-when tls  (.put "mail.smtp.starttls.enable" "true"))))


### PR DESCRIPTION
We were trying to get postal to work with CRAM-MD5 and had issues. This
enables sasl by default and allows you to disable it by passing in
`:sasl false`.