### PR TITLE
Avoid setting 'sender:' header when :sender key included in message

### DIFF
--- a/src/postal/message.clj
+++ b/src/postal/message.clj
@@ -156,7 +156,7 @@
   ([msg session]
      (let [standard [:from :reply-to :to :cc :bcc
                      :date :subject :body :message-id
-                     :user-agent]
+                     :user-agent :sender]
            charset (or (:charset msg) default-charset)
            jmsg (proxy [MimeMessage] [session]
                   (updateMessageID []

--- a/test/postal/test/message.clj
+++ b/test/postal/test/message.clj
@@ -225,3 +225,12 @@
             :body "Where is that message ID!"
             :user-agent "foo/1.0"})]
     (is (.contains m "User-Agent: foo"))))
+
+(deftest test-sender
+  (let [m (message->str
+           {:sender "foo@bar.dom"
+            :to "baz@bar.dom"
+            :subject "Test"
+            :body "Test!"})]
+    (is (.contains m "From: foo@bar.dom"))
+    (is (not (.contains m "sender:")))))


### PR DESCRIPTION
The :sender key is intended to specify the envelope sender for a message and should not appear as an extra "sender:" email header.