### PR TITLE
Use :from for From header when both :from and :sender keys are present

### DIFF
--- a/src/postal/message.clj
+++ b/src/postal/message.clj
@@ -167,9 +167,8 @@
          (add-recipients! Message$RecipientType/TO (:to msg) charset)
          (add-recipients! Message$RecipientType/CC (:cc msg) charset)
          (add-recipients! Message$RecipientType/BCC (:bcc msg) charset)
-         (.setFrom (if-let [sender (:sender msg)]
-                     (make-address sender charset)
-                     (make-address (:from msg) charset)))
+         (.setFrom (let [{:keys [from sender]} msg]
+                     (make-address (or from sender) charset)))
          (.setReplyTo (when-let [reply-to (:reply-to msg)]
                         (make-addresses reply-to charset)))
          (.setSubject (:subject msg) charset)

--- a/test/postal/test/message.clj
+++ b/test/postal/test/message.clj
@@ -225,3 +225,20 @@
             :body "Where is that message ID!"
             :user-agent "foo/1.0"})]
     (is (.contains m "User-Agent: foo"))))
+
+(deftest test-sender
+  (let [m (message->str
+           {:sender "sender@bar.dom"
+            :to "baz@bar.dom"
+            :subject "Test"
+            :body "Test!"})]
+    (is (.contains m "From: sender@bar.dom"))))
+
+(deftest test-from-and-sender
+  (let [m (message->str
+           {:sender "sender@bar.dom"
+            :from "from@bar.dom"
+            :to "baz@bar.dom"
+            :subject "Test"
+            :body "Test!"})]
+    (is (.contains m "From: from@bar.dom"))))


### PR DESCRIPTION
When both :from and :sender are present in a message, :from should be used for the "From:" header.