### PR TITLE
Fix reflection warning

### DIFF
--- a/src/postal/sendmail.clj
+++ b/src/postal/sendmail.clj
@@ -68,9 +68,9 @@
      (sendmail-send msg (find-sendmail)))
   ([msg sendmail]
       (let [mail (sanitize (message->str msg))
-            cmd (concat
-                 [sendmail (format "-f %s" (sender msg))]
-                 (recipients msg))
+            ^java.util.List cmd (concat
+                                 [sendmail (format "-f %s" (sender msg))]
+                                 (recipients msg))
             pb (ProcessBuilder. cmd)
             p (.start pb)
             smtp (java.io.PrintStream. (.getOutputStream p))]


### PR DESCRIPTION
Signature of set-body! function was changed due to removal of unused
'charset' parameter. The method 'setText' of javax.mail.Message accepts
only one parameter (the body of message) there is no need to provide
character set information there.
