### PR TITLE
Allow local address configuration for multihomed hosts

### DIFF
--- a/src/postal/support.clj
+++ b/src/postal/support.clj
@@ -31,14 +31,16 @@
   `(when ~condition
      (doto ~arg ~@body)))
 
-(defn make-props [sender {:keys [host port user tls]}]
+(defn make-props [sender {:keys [host port user tls localhost localaddress]}]
   (doto (Properties.)
     (.put "mail.smtp.host" (or host "not.provided"))
     (.put "mail.smtp.port" (or port "25"))
     (.put "mail.smtp.auth" (if user "true" "false"))
     (do-when sender (.put "mail.smtp.from" sender))
     (do-when user (.put "mail.smtp.user" user))
-    (do-when tls  (.put "mail.smtp.starttls.enable" "true"))))
+    (do-when tls  (.put "mail.smtp.starttls.enable" "true"))
+    (do-when localhost (.put "mail.smtp.localhost" localhost))
+    (do-when localaddress (.put "mail.smtp.localaddress" localaddress))))
 
 (defn hostname []
   (.getHostName (java.net.InetAddress/getLocalHost)))

--- a/test/postal/test/smtp.clj
+++ b/test/postal/test/smtp.clj
@@ -65,4 +65,12 @@
              :pass nil}
             {"mail.smtp.port" 25
              "mail.smtp.auth" "false"
-             "mail.smtp.host" "smtp.bar.dom"}))
+             "mail.smtp.host" "smtp.bar.dom"})
+  (is-props {:host "smtp.bar.dom"
+             :localaddress "1.2.3.4"
+             :localhost "mail.bar.dom"}
+            {"mail.smtp.port" 25
+             "mail.smtp.auth" "false"
+             "mail.smtp.host" "smtp.bar.dom"
+             "mail.smtp.localaddress" "1.2.3.4"
+             "mail.smtp.localhost" "mail.bar.dom"}))

--- a/test/postal/test/smtp.clj
+++ b/test/postal/test/smtp.clj
@@ -55,6 +55,15 @@
   (is-props {:host "smtp.bar.dom"
              :user "foo"
              :pass "pass"
+             :tls :y}
+            {"mail.smtp.user" "foo"
+             "mail.smtp.port" 25
+             "mail.smtp.auth" "true"
+             "mail.smtp.starttls.enable" "true"
+             "mail.smtp.host" "smtp.bar.dom"})
+  (is-props {:host "smtp.bar.dom"
+             :user "foo"
+             :pass "pass"
              :ssl :y}
             {"mail.smtp.user" "foo"
              "mail.smtp.port" 465

--- a/test/postal/test/smtp.clj
+++ b/test/postal/test/smtp.clj
@@ -73,4 +73,12 @@
              "mail.smtp.auth" "false"
              "mail.smtp.host" "smtp.bar.dom"
              "mail.smtp.localaddress" "1.2.3.4"
+             "mail.smtp.localhost" "mail.bar.dom"})
+  (is-props {:host "smtp.bar.dom"
+             "mail.smtp.localaddress" "1.2.3.4"
+             "mail.smtp.localhost" "mail.bar.dom"}
+            {"mail.smtp.port" 25
+             "mail.smtp.auth" "false"
+             "mail.smtp.host" "smtp.bar.dom"
+             "mail.smtp.localaddress" "1.2.3.4"
              "mail.smtp.localhost" "mail.bar.dom"}))


### PR DESCRIPTION
Two new `mail.smtp` properties are made accessible:

- `localhost` sets the host name used in the EHLO command.
- `localaddress` sets the address to bind to when generating the outbound connection (for multihomed hosts).