### PR TITLE
Add content transfer encoding for attachments

### DIFF
--- a/src/postal/message.clj
+++ b/src/postal/message.clj
@@ -103,6 +103,8 @@
 
       (when (:content-type part)
         (.setHeader attachment-part "Content-Type" (:content-type part)))
+      (when (:content-encoding part)
+        (.setHeader attachment-part "Content-Transfer-Encoding" (:content-encoding part)))
       (when (:content-id part)
         (.setContentID attachment-part (str "<" (:content-id part) ">")))
       (when (:file-name part)


### PR DESCRIPTION
add configuration for setting the content transfer encoding of an attachment

e.g:
send-message {:host "mail.isp.net"}
                           {:from "me@draines.com"
                            :to "foo@example.com"
                            :subject "Hi!"
                            :body [{:type "text/html"
                                    :content "<b>Test!</b>"}
                                   {:type :attachment
                                    :content-type "application/octet-stream"
                                    :content-encoding "base64"
                                    :content (java.io.File. "/tmp/foo.txt")}
                                   {:type :inline
                                    :content (java.io.File. "/tmp/a.pdf")
                                    :content-type "application/pdf"}]})