### PR TITLE
Allow user to pass through any javamail settings they wish

### DIFF
--- a/test/postal/test/smtp.clj
+++ b/test/postal/test/smtp.clj
@@ -65,4 +65,15 @@
              :pass nil}
             {"mail.smtp.port" 25
              "mail.smtp.auth" "false"
-             "mail.smtp.host" "smtp.bar.dom"}))
+             "mail.smtp.host" "smtp.bar.dom"})
+  (is-props {:host "smtp.bar.dom"
+             :user nil
+             :pass nil
+             :mail.smtp.foo "bar"
+             :mail.smtp.baz "buzz"
+             :this.is "ignored"}
+            {"mail.smtp.port" 25
+             "mail.smtp.auth" "false"
+             "mail.smtp.host" "smtp.bar.dom"
+             "mail.smtp.foo" "bar"
+             "mail.smtp.baz" "buzz"}))


### PR DESCRIPTION
We would like to supply settings such as mail.smtp.timeout which currently isn't possible as only a select few keys are supplied to the javamail api.

This change allows any mail.smtp.* setting to propagate through to the javamail api.