### PR TITLE
Add "mail.smtp.ssl.trust" property support

### DIFF
--- a/src/postal/support.clj
+++ b/src/postal/support.clj
@@ -31,14 +31,15 @@
   `(when ~condition
      (doto ~arg ~@body)))
 
-(defn make-props [sender {:keys [host port user tls]}]
+(defn make-props [sender {:keys [host port user tls ssl-trust]}]
   (doto (Properties.)
     (.put "mail.smtp.host" (or host "not.provided"))
     (.put "mail.smtp.port" (or port "25"))
     (.put "mail.smtp.auth" (if user "true" "false"))
     (do-when sender (.put "mail.smtp.from" sender))
     (do-when user (.put "mail.smtp.user" user))
-    (do-when tls  (.put "mail.smtp.starttls.enable" "true"))))
+    (do-when tls (.put "mail.smtp.starttls.enable" "true"))
+    (do-when ssl-trust (.put "mail.smtp.ssl.trust" ssl-trust))))
 
 (defn hostname []
   (.getHostName (java.net.InetAddress/getLocalHost)))


### PR DESCRIPTION
Hello! I was having a hard time with this error:

```java
Unable to send mail: #<MessagingException javax.mail.MessagingException: Could not convert socket to TLS;
  nested exception is:
  javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target>  stack trace:
 com.sun.mail.smtp.SMTPTransport.startTLS(SMTPTransport.java:1880)
com.sun.mail.smtp.SMTPTransport.protocolConnect(SMTPTransport.java:648)
javax.mail.Service.connect(Service.java:295)
postal.smtp$smtp_send_STAR_.invoke(smtp.clj:33)
postal.smtp$smtp_send.doInvoke(smtp.clj:58)
clojure.lang.RestFn.invoke(RestFn.java:423)
postal.core$send_message.invoke(core.clj:35)
clojurewerkz.mailer.core$deliver_with_smtp.doInvoke(core.clj:48)
clojure.lang.RestFn.invoke(RestFn.java:470)
clojure.lang.AFn.applyToHelper(AFn.java:165)
clojure.lang.RestFn.applyTo(RestFn.java:132)
clojure.core$apply.doInvoke(core.clj:632)
clojure.lang.RestFn.invoke(RestFn.java:533)
clojurewerkz.mailer.core$deliver_email.doInvoke(core.clj:148)
clojure.lang.RestFn.invoke(RestFn.java:470)
dosierer.mailer$send_email$fn__166.invoke(mailer.clj:26)
clojure.core$binding_conveyor_fn$fn__4145.invoke(core.clj:1910)
clojure.lang.AFn.call(AFn.java:18)
java.util.concurrent.FutureTask.run(FutureTask.java:266)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
java.lang.Thread.run(Thread.java:745)
```

After seeing [this](http://stackoverflow.com/a/17799656/600052) answer, and added following patch, I was able to send emails.

`make-props` now returns the following:

```clojure
#<Properties {mail.smtp.starttls.enable=true,
              mail.smtp.user=user@host.com,
              mail.smtp.port=25,
              mail.smtp.ssl.trust=smtp.host.com,
              mail.smtp.auth=true,
              mail.smtp.host=smtp.host.com,
              mail.smtp.from=from@host.com}>
```
