### PR TITLE
Throw an exception if sendmail is not installed on system.

### DIFF
--- a/src/postal/sendmail.clj
+++ b/src/postal/sendmail.clj
@@ -58,7 +58,8 @@
 (defn find-sendmail []
   (if-let [SENDMAIL (System/getenv "SENDMAIL")]
     SENDMAIL
-    (first (filter #(.isFile (java.io.File. ^String %)) sendmails))))
+    (or (first (filter #(.isFile (java.io.File. ^String %)) sendmails))
+        (throw (ex-info "Can't find sendmail executable. Is sendmail installed?" {:searched-for sendmails})))))
 
 (defn sanitize [^String text]
   (.replaceAll text "\r\n" (System/getProperty "line.separator")))


### PR DESCRIPTION
Hi,
I was using postal on a machine that didn't have sendmail installed, and postal didn't handle this gracefully, so I thought I'd add a more useful exception.
