### PR TITLE
Allow file-name and description to be set on all content parts

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,5 @@
   :repositories {"java.net" "http://download.java.net/maven/2"}
   :dependencies [[commons-codec "1.9"]
                  [javax.mail/mail "1.4.4"
-                  :exclusions [javax.activation/activation]]
-                 [com.palletops/thread-expr "1.3.0"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
-             :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}})
+                  :exclusions [javax.activation/activation]]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]]}})

--- a/src/postal/message.clj
+++ b/src/postal/message.clj
@@ -24,7 +24,6 @@
 (ns postal.message
   (:use [clojure.set :only [difference]]
         [clojure.java.io :only [as-url as-file]]
-        [pallet.thread-expr :refer [when->]]
         [postal.date :only [make-date]]
         [postal.support :only [do-when make-props message-id user-agent]])
   (:import [java.util UUID]
@@ -110,19 +109,19 @@
         (.setDataHandler (DataHandler. url))
         (.setFileName (re-find #"[^/]+$" (.getPath url)))
         (.setDisposition (name (:type part)))
-        (when-> (:content-type part)
+        (cond-> (:content-type part)
                 (.setHeader "Content-Type" (:content-type part)))
-        (when-> (:content-id part)
+        (cond-> (:content-id part)
                 (.setContentID (str "<" (:content-id part) ">")))
-        (when-> (:file-name part)
+        (cond-> (:file-name part)
                 (.setFileName (:file-name part)))
-        (when-> (:description part)
+        (cond-> (:description part)
                 (.setDescription (:description part)))))
     (doto (javax.mail.internet.MimeBodyPart.)
       (.setContent (:content part) (:type part))
-      (when-> (:file-name part)
+      (cond-> (:file-name part)
               (.setFileName (:file-name part)))
-      (when-> (:description part)
+      (cond-> (:description part)
               (.setDescription (:description part))))))
 
 (defn eval-multipart [parts]

--- a/src/postal/message.clj
+++ b/src/postal/message.clj
@@ -119,8 +119,13 @@
       (when (:description part)
         (.setDescription attachment-part (:description part)))
       attachment-part)
-    (doto (javax.mail.internet.MimeBodyPart.)
-      (.setContent (:content part) (:type part)))))
+    (let [mime-part (javax.mail.internet.MimeBodyPart.)]
+      (.setContent mime-part (:content part) (:type part))
+      (when (:file-name part)
+        (.setFileName mime-part (:file-name part)))
+      (when (:description part)
+        (.setDescription mime-part (:description part)))
+      mime-part)))
 
 (defn eval-multipart [parts]
   (let [;; multiparts can have a number of different types: mixed,

--- a/test/postal/test/message.clj
+++ b/test/postal/test/message.clj
@@ -56,6 +56,22 @@
     (is (.contains m "Content-Type: text/html"))
     (is (.contains m "some html"))))
 
+(deftest test-multipart-with-custom-name-and-description
+  (let [m (message->str
+           {:from "foo@bar.dom"
+            :to "baz@bar.dom"
+            :subject "Test"
+            :body [{:type "text/plain"
+                    :content "See attached"}
+                   {:type "text/csv"
+                    :file-name "data.csv"
+                    :description "Some interesting data"
+                    :content "x,2x\n1,2,\n2,4\n"}]})]
+    (is (.contains m "See attached"))
+    (is (.contains m "data.csv"))
+    (is (.contains m "Some interesting data"))
+    (is (.contains m "x,2x\n1,2,\n2,4\n"))))
+
 (deftest test-inline
   (let [f (doto (java.io.File/createTempFile "_postal-" ".txt"))
         _ (doto (java.io.PrintWriter. f)


### PR DESCRIPTION
This allows file-name to be set on all parts of the message, not just attachments.
Here's an example of including some csv data in an email:

```
(send-email
  {:from "bo@"
   :to addresses
   :subject "hi"
   :body [{:type "text/plain"
           :content "I attached a csv"}
          {:type "text/csv"
           :file-name "data.csv"
           :content csv-content}]})
```