### PR TITLE
Convert keywords to both mail.smtp. and mail.smtps. properties

### DIFF
--- a/src/postal/support.clj
+++ b/src/postal/support.clj
@@ -50,18 +50,19 @@
         defaults {:host "not.provided"
                   :port (if ssl 465 25)
                   :auth (boolean user)}]
-    (into {}
-          (for [[k v] (merge defaults
-                             (if sender {:from sender} {})
-                             (dissoc params :pass :ssl :proto))
-                :when (not (nil? v))
-                :let [k (if (prop-map k) (prop-map k) k)
-                      v (if (or (instance? Boolean v) (boolean-props k))
-                          (if v "true" "false")
-                          v)]]
-            (if (keyword? k)
-              [(str "mail.smtp." (name k)) v]
-              [k v])))))
+    (into {} (apply concat
+                    (for [[k v] (merge defaults
+                                       (if sender {:from sender} {})
+                                       (dissoc params :pass :ssl :proto))
+                          :when (not (nil? v))
+                          :let [k (if (prop-map k) (prop-map k) k)
+                                v (if (or (instance? Boolean v) (boolean-props k))
+                                    (if v "true" "false")
+                                    v)]]
+                      (if (keyword? k)
+                        [[(str "mail.smtp." (name k)) v]
+                         [(str "mail.smtps." (name k)) v]]
+                        [[k v]]))))))
 
 (defn make-props [sender params]
   (let [p (Properties.)]

--- a/test/postal/test/smtp.clj
+++ b/test/postal/test/smtp.clj
@@ -44,14 +44,21 @@
   (is-props {:host "smtp.bar.dom"}
             {"mail.smtp.port" 25
              "mail.smtp.auth" "false"
-             "mail.smtp.host" "smtp.bar.dom"})
+             "mail.smtp.host" "smtp.bar.dom"
+             "mail.smtps.port" 25
+             "mail.smtps.auth" "false"
+             "mail.smtps.host" "smtp.bar.dom"})
   (is-props {:host "smtp.bar.dom"
              :user "foo"
              :pass "pass"}
             {"mail.smtp.user" "foo"
              "mail.smtp.port" 25
              "mail.smtp.auth" "true"
-             "mail.smtp.host" "smtp.bar.dom"})
+             "mail.smtp.host" "smtp.bar.dom"
+             "mail.smtps.user" "foo"
+             "mail.smtps.port" 25
+             "mail.smtps.auth" "true"
+             "mail.smtps.host" "smtp.bar.dom"})
   (is-props {:host "smtp.bar.dom"
              :user "foo"
              :pass "pass"
@@ -60,7 +67,12 @@
              "mail.smtp.port" 25
              "mail.smtp.auth" "true"
              "mail.smtp.starttls.enable" "true"
-             "mail.smtp.host" "smtp.bar.dom"})
+             "mail.smtp.host" "smtp.bar.dom"
+             "mail.smtps.user" "foo"
+             "mail.smtps.port" 25
+             "mail.smtps.auth" "true"
+             "mail.smtps.starttls.enable" "true"
+             "mail.smtps.host" "smtp.bar.dom"})
   (is-props {:host "smtp.bar.dom"
              :user "foo"
              :pass "pass"
@@ -68,13 +80,20 @@
             {"mail.smtp.user" "foo"
              "mail.smtp.port" 465
              "mail.smtp.auth" "true"
-             "mail.smtp.host" "smtp.bar.dom"})
+             "mail.smtp.host" "smtp.bar.dom"
+             "mail.smtps.user" "foo"
+             "mail.smtps.port" 465
+             "mail.smtps.auth" "true"
+             "mail.smtps.host" "smtp.bar.dom"})
   (is-props {:host "smtp.bar.dom"
              :user nil
              :pass nil}
             {"mail.smtp.port" 25
              "mail.smtp.auth" "false"
-             "mail.smtp.host" "smtp.bar.dom"})
+             "mail.smtp.host" "smtp.bar.dom"
+             "mail.smtps.port" 25
+             "mail.smtps.auth" "false"
+             "mail.smtps.host" "smtp.bar.dom"})
   (is-props {:host "smtp.bar.dom"
              :localaddress "1.2.3.4"
              :localhost "mail.bar.dom"}
@@ -82,12 +101,20 @@
              "mail.smtp.auth" "false"
              "mail.smtp.host" "smtp.bar.dom"
              "mail.smtp.localaddress" "1.2.3.4"
-             "mail.smtp.localhost" "mail.bar.dom"})
+             "mail.smtp.localhost" "mail.bar.dom"
+             "mail.smtps.port" 25
+             "mail.smtps.auth" "false"
+             "mail.smtps.host" "smtp.bar.dom"
+             "mail.smtps.localaddress" "1.2.3.4"
+             "mail.smtps.localhost" "mail.bar.dom"})
   (is-props {:host "smtp.bar.dom"
              "mail.smtp.localaddress" "1.2.3.4"
              "mail.smtp.localhost" "mail.bar.dom"}
             {"mail.smtp.port" 25
              "mail.smtp.auth" "false"
              "mail.smtp.host" "smtp.bar.dom"
+             "mail.smtps.port" 25
+             "mail.smtps.auth" "false"
+             "mail.smtps.host" "smtp.bar.dom"
              "mail.smtp.localaddress" "1.2.3.4"
              "mail.smtp.localhost" "mail.bar.dom"}))


### PR DESCRIPTION
Per (the docs)[https://javamail.java.net/nonav/docs/api/com/sun/mail/smtp/package-summary.html]:

> Note that if you're using the "smtps" protocol to access SMTP over SSL, all
> the properties would be named "mail.smtps.*".

At present, we always set only `mail.smtp` properties from keywords.

Granted, we could try to determine the protocol from inspecting the properties passed, but always setting properties for both possibilities is the more robust approach, precluding any possibility of making the determination wrongly.