### PR TITLE
Support using make-address to build a message.

### DIFF
--- a/test/postal/test/message.clj
+++ b/test/postal/test/message.clj
@@ -231,6 +231,14 @@
             :reply-to "yermom@bar.dom"})]
     (is (.contains m "Reply-To: yermom"))))
 
+(deftest test-make-address-to
+  (let [m (message->str
+           {:from "foo@bar.dom"
+            :to (make-address "bob@bar.dom" "To > Bob" "UTF-8")
+            :subject "Test"            
+            :body "Test"})]
+    (is (.contains m "\"To > Bob\" <bob@bar.dom>"))))
+
 (deftest test-only-bcc
   (let [m (message->str
            {:from "foo@bar.dom"


### PR DESCRIPTION
The main use case is to support the 3 args version of make-address, thus allowing to better validate an e-mail display-name. Sending an e-mail with characters like < or > is now posssible because InternetAddress takes care of properly quoting the display-name (aka personal name).
