### PR TITLE
Resolve reflection warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,5 @@
   :dependencies [[commons-codec "1.9"]
                  [com.sun.mail/javax.mail "1.5.5"]
                  [javax.mail/javax.mail-api "1.5.5"]]
+  :global-vars {*warn-on-reflection* true}
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]]}})

--- a/src/postal/sendmail.clj
+++ b/src/postal/sendmail.clj
@@ -71,7 +71,7 @@
             cmd (concat
                  [sendmail "-f" (sender msg)]
                  (recipients msg))
-            pb (ProcessBuilder. cmd)
+            pb (ProcessBuilder. ^java.util.List cmd)
             p (.start pb)
             smtp (java.io.PrintStream. (.getOutputStream p))]
         (.print smtp mail)

--- a/test/postal/test/message.clj
+++ b/test/postal/test/message.clj
@@ -175,7 +175,7 @@
   (let [from "foo@bar.dom"
         to "baz@bar.dom"
         tag "[TEST]"]
-    (is (zero? (.indexOf (:subject (make-fixture from to :tag tag)) "[TEST")))))
+    (is (zero? (.indexOf ^String (:subject (make-fixture from to :tag tag)) "[TEST")))))
 
 (deftest test-extra-headers
   (let [m {:from "foo@bar.dom"

--- a/test/postal/test/smtp.clj
+++ b/test/postal/test/smtp.clj
@@ -30,12 +30,8 @@
              :to "baz@bar.dom"
              :subject "Test"
              :body "Hello."}]
-    (binding [smtp/smtp-send* (fn [& args] args)]
-      (->>
-       (smtp/smtp-send attrs [msg])
-       first
-       .getProperties
-       (into {})))))
+    (binding [smtp/smtp-send* (fn [^javax.mail.Session session & _] (into {} (.getProperties session)))]
+      (smtp/smtp-send attrs [msg]))))
 
 (defmacro is-props [input want]
   `(is (= (props ~input) ~want)))


### PR DESCRIPTION
Reflection warnings indicate compile time type ambiguity that is resolved at runtime with a dynamic dispatch. This causes a small runtime cost that is not usually a problem, but can also mask type errors, for example `set-body!` which claims to accept a `javax.mail.Message` but actually requires a `javax.mail.internet.MimeMessage`.

Even if postal does not benefit from resolving type ambiguities, downstream users may have very good reasons for enabling reflection warnings so it would be nice if postal (and similar libraries) could avoid generating reflection warnings in their core namespaces so that they don't generate noise for downstream users.

This change is split into three commits:

1) Enable reflection warnings: this commit is optional, but will help avoid regressions
2) Resolve ambiguities in core namespaces: this commit is the meat of the change
3) Resolve ambiguities in test namespaces: if you accept (1) you probably want this too

I have tried to avoid any changes to behaviour, or the signatures of public vars. The exceptions to this are `message->str`, where I added a return type hint to resolve a lot of warnings in test code, and `add-body!`, where I resolved a potential bug where a `MimeMessage` was expected but the API claims to take a `Message`. I changed the code to support `Message` in both paths so that the API remains consistent, but you may prefer to change to `MimeMessage` and eliminate the extra conditional.