### PR TITLE
Add support for attachments and inline attachments as bytes arrays.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.draines/postal "3.0.0-SNAPSHOT"
+(defproject com.intception/postal "3.0.1"
   :description "JavaMail on Clojure"
   :url "https://github.com/drewr/postal"
   :license {:name "MIT"

--- a/src/postal/support.clj
+++ b/src/postal/support.clj
@@ -86,10 +86,11 @@
        (format "<%s.%s@%s>" onlychars epoch host))))
 
 (defn pom-version []
-  (let [pom "META-INF/maven/com.draines/postal/pom.properties"
-        props (doto (Properties.)
-                (.load (-> pom io/resource io/input-stream)))]
-    (.getProperty props "version")))
+  (if-let [pom (io/resource "META-INF/maven/com.draines/postal/pom.properties")]
+    (let [props (doto (Properties.)
+                  (.load (io/input-stream pom)))]
+      (.getProperty props "version"))
+    ""))
 
 (defn user-agent []
   (let [prop (Properties.)


### PR DESCRIPTION
Now only files were supported so if content was part of a stream it was necessary to pivot in a temporary file.

`:content` is assumed to be a byte array of a base64 encoded file.