### PR TITLE
Added support for content-id in all body parts

### DIFF
--- a/src/postal/message.clj
+++ b/src/postal/message.clj
@@ -124,6 +124,8 @@
                 (.setDescription (:description part)))))
     (doto (javax.mail.internet.MimeBodyPart.)
       (.setContent (:content part) (:type part))
+      (cond-> (:content-id part)
+              (.setContentID (str "<" (:content-id part) ">")))
       (cond-> (:file-name part)
               (.setFileName (encode-filename (:file-name part))))
       (cond-> (:description part)


### PR DESCRIPTION
Added support for content-id in attachments which are not type :attachment or :inline. This enables passing byte arrays as content for inline images, as requested in #87.

I added a test for this case, using a byte array representing a minimal valid PNG file.