### PR TITLE
Fix pom version bug

### DIFF
--- a/src/postal/support.clj
+++ b/src/postal/support.clj
@@ -86,13 +86,15 @@
        (format "<%s.%s@%s>" onlychars epoch host))))
 
 (defn pom-version []
-  (let [pom "META-INF/maven/com.draines/postal/pom.properties"
-        props (doto (Properties.)
-                (.load (-> pom io/resource io/input-stream)))]
-    (.getProperty props "version")))
+  (when-let [is (some-> (io/resource "META-INF/maven/com.draines/postal/pom.properties")
+                        io/input-stream)]
+    (.getProperty (doto (Properties.)
+                    (.load is))
+                  "version")))
 
 (defn user-agent []
-  (let [prop (Properties.)
-        ver (or (System/getProperty "postal.version")
-                (pom-version))]
-    (format "postal/%s" ver)))
+  (if-let [version (or (System/getProperty "postal.version")
+                       (pom-version))]
+    (format "postal/%s"
+            version)
+    "postal"))


### PR DESCRIPTION
This problem is odd, very odd, I don't fully understand it. It appeared out of nowhere when using postal on the raspberry pi, if that's relevant.


Before this fix, `postal.support/pom-version` would sometimes throw a
null pointer exception because it could not find the relevant pom file.
Now, this function returns nil instead.

Furthermore, `postal.support/user-agent` has been corrected accordingly.