### PR TITLE
Add bytes attachments

### DIFF
--- a/src/postal/message.clj
+++ b/src/postal/message.clj
@@ -30,7 +30,8 @@
            [java.net MalformedURLException]
            [javax.activation DataHandler]
            [javax.mail Message Message$RecipientType PasswordAuthentication Session]
-           [javax.mail.internet InternetAddress MimeMessage]))
+           [javax.mail.internet InternetAddress MimeMessage]
+           [javax.mail.util ByteArrayDataSource]))
 
 (def default-charset "utf-8")
 
@@ -105,23 +106,36 @@
 (defn- encode-filename [filename]
   (. javax.mail.internet.MimeUtility encodeText filename "UTF-8" nil))
 
-(defn eval-bodypart [part]
-  (condp (fn [test type] (some #(= % type) test)) (:type part)
-    [:inline :attachment]
-    (let [url (make-url (:content part))]
+(defprotocol MimeBodyPart
+  (^javax.mail.internet.MimeBodyPart mime-body-part [content part]))
+
+(extend-protocol MimeBodyPart
+  (class (make-array Byte/TYPE 0))
+  (mime-body-part [content {:keys [content-type]}]
+    (let [src (ByteArrayDataSource. ^bytes content ^String content-type)]
+      (doto (javax.mail.internet.MimeBodyPart.)
+        (.setDataHandler (DataHandler. src)))))
+  Object
+  (mime-body-part [content _]
+    (let [url (make-url content)]
       (doto (javax.mail.internet.MimeBodyPart.)
         (.setDataHandler (DataHandler. url))
         (.setFileName (-> (re-find #"[^/]+$" (.getPath url))
-                          encode-filename))
-        (.setDisposition (name (:type part)))
-        (cond-> (:content-type part)
-                (.setHeader "Content-Type" (:content-type part)))
-        (cond-> (:content-id part)
-                (.setContentID (str "<" (:content-id part) ">")))
-        (cond-> (:file-name part)
-                (.setFileName (encode-filename (:file-name part))))
-        (cond-> (:description part)
-                (.setDescription (:description part)))))
+                          encode-filename))))))
+
+(defn eval-bodypart [part]
+  (condp (fn [test type] (some #(= % type) test)) (:type part)
+    [:inline :attachment]
+    (doto (mime-body-part (:content part) part)
+      (.setDisposition (name (:type part)))
+      (cond-> (:content-type part)
+              (.setHeader "Content-Type" (:content-type part)))
+      (cond-> (:content-id part)
+              (.setContentID (str "<" (:content-id part) ">")))
+      (cond-> (:file-name part)
+              (.setFileName (encode-filename (:file-name part))))
+      (cond-> (:description part)
+              (.setDescription (:description part))))
     (doto (javax.mail.internet.MimeBodyPart.)
       (.setContent (:content part) (:type part))
       (cond-> (:file-name part)

--- a/test/postal/test/message.clj
+++ b/test/postal/test/message.clj
@@ -104,6 +104,20 @@
     (is (not (.contains m "etc")))
     (.delete f1)))
 
+(deftest test-attachment-from-bytes
+  (let [b (.getBytes "foo")
+        m (message->str
+            {:from "x@x.dom"
+             :to "y@y.dom"
+             :subject "Test"
+             :body [{:type :attachment
+                     :content b
+                     :content-type "bar/bar"
+                     :file-name "baz"}]})]
+    (is (.contains m "foo"))
+    (is (.contains m "bar/bar"))
+    (is (.contains m "baz"))))
+
 (deftest test-attachments-from-url
   (let [jar (doto (java.io.File/createTempFile "_postal-" ".jar"))
         _ (with-open [zip-out (ZipOutputStream. (io/output-stream jar))


### PR DESCRIPTION
It is handy to be able to use a byte array rather than a file as the attachment `:content`. Test included.