### PR TITLE
Fix tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "37:cc:ad:b6:53:7a:98:22:83:fb:d8:77:12:cf:8c:92"
+            - "a6:08:d9:a8:b8:92:c3:d2:19:f4:0b:af:a6:8b:2b:7c"
       - checkout
       - restore_cache:
           key: << checksum "project.clj" >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
     docker:
       - image: clojure:lein-2.9.1
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "37:cc:ad:b6:53:7a:98:22:83:fb:d8:77:12:cf:8c:92"
       - checkout
       - restore_cache:
           key: << checksum "project.clj" >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: clojure:lein-2.8.1
+      - image: clojure:lein-2.9.1
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: clojure:lein-2.9.1
+      - image: clojure:openjdk-8-lein-2.9.1
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ SSL.
 
 ### Dependencies
 
-* JavaMail 1.5.5 (in `lib/` after build)
+* JavaMail (in `lib/` after build)
+* Java 8 (does not currently work with 11+)
 
 ### Install
 

--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,8 @@
             :comments "Use at your own risk"}
   :deploy-repositories [["releases" :clojars]]
   :dependencies [[commons-codec "1.9"]
-                 [com.sun.mail/javax.mail "1.5.5"]
-                 [javax.mail/javax.mail-api "1.5.5"]]
+                 [com.sun.mail/javax.mail "1.6.2"]
+                 [javax.mail/javax.mail-api "1.6.2"]]
   :global-vars {*warn-on-reflection* true}
   :profiles {:dev {:dependencies []}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}


### PR DESCRIPTION
The tests weren't passing in CI, a few notes:

1. The reference to the Docker image `clojure:lein-2.8.1` was stale
2. Updating that to `clojure:lein-2.9.1` also bumped to Java 11, which revealed an incompatibility (I think) between Java 11 and JavaMail. I don't have time to fix right now.
3. Updated JavaMail to 1.6.2, but that seems ok.
4. Using `clojure:openjdk-8-lein-2.9.1` works, so we'll go with that for now.