### PR TITLE
Allows to specify a body with custom Content-Type.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.draines/postal "3.0.0-SNAPSHOT"
+(defproject com.draines/postal "2.0.4-SNAPSHOT"
   :description "JavaMail on Clojure"
   :url "https://github.com/drewr/postal"
   :license {:name "MIT"

--- a/src/postal/message.clj
+++ b/src/postal/message.clj
@@ -151,10 +151,18 @@
   jmsg)
 
 (defn add-body! [^javax.mail.Message jmsg body charset]
-  (if (string? body)
+  (cond
+    (string? body)
     (if (instance? MimeMessage jmsg)
       (doto ^MimeMessage jmsg (.setText body charset))
       (doto jmsg (.setText body)))
+
+    (map? body)
+    (let [{:keys [content, type] :or {type "text/plain"}} body]
+      (doto jmsg
+        (.setContent content, type)))
+
+    :else
     (doto jmsg (add-multipart! body))))
 
 (defn make-auth [user pass]


### PR DESCRIPTION
With Postal 2.0.3 it is not possible to send emails with HTML content instead of plain text.
This adds support for specifying a map as body that contains `:content` and `:type`.

For the HTML use case, the body can be specified as:
```clojure
:body {:type "text/html", :content "<h1>HTML Email</h1>"}
```