### PR TITLE
Body before headers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,5 +13,5 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.2-rc1"]]}}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.2"]]}}
   :aliases {"test-all" ["with-profile" "dev,1.7:dev,1.8:dev,1.9:dev,1.10" "test"]})

--- a/src/postal/message.clj
+++ b/src/postal/message.clj
@@ -195,8 +195,8 @@
        (.setSubject (:subject msg) ^String charset)
        (.setSentDate (or (:date msg) (make-date)))
        (.addHeader "User-Agent" (:user-agent msg (user-agent)))
-       (add-extra! (apply dissoc msg standard))
        (add-body! (:body msg) charset)
+       (add-extra! (apply dissoc msg standard))
        (.saveChanges)))))
 
 (defn make-fixture [from to & {:keys [tag]}]

--- a/src/postal/message.clj
+++ b/src/postal/message.clj
@@ -195,8 +195,8 @@
        (.setSubject (:subject msg) ^String charset)
        (.setSentDate (or (:date msg) (make-date)))
        (.addHeader "User-Agent" (:user-agent msg (user-agent)))
-       (add-body! (:body msg) charset)
        (add-extra! (apply dissoc msg standard))
+       (add-body! (:body msg) charset)
        (.saveChanges)))))
 
 (defn make-fixture [from to & {:keys [tag]}]

--- a/test/postal/test/message.clj
+++ b/test/postal/test/message.clj
@@ -199,8 +199,10 @@
            :to "baz@bar.dom"
            :subject "Test"
            :User-Agent "Lorem Ipsum"
-           :body "Foo!"}]
-    (is (.contains (message->str m) "User-Agent: Lorem Ipsum"))))
+           :Content-Type "text/html"
+           :body "<html><body>Foo!</body></html>"}]
+    (is (.contains (message->str m) "User-Agent: Lorem Ipsum"))
+    (is (= (.getContentType (make-jmessage m)) "text/html"))))
 
 (deftest test-bad-addrs
   (let [m (message->str
@@ -312,13 +314,3 @@
             :subject "Test"
             :body "Test!"})]
     (is (.contains m "From: from@bar.dom"))))
-
-(deftest test-make-jmessage
-  (let [^MimeMessage m (make-jmessage
-                        {:sender "sender@bar.dom"
-                         :from "from@bar.dom"
-                         :to "baz@bar.dom"
-                         :subject "Test"
-                         :Content-Type "text/html"
-                         :body "<html><body>Test!</body></html>"})]
-    (is (= "text/html" (.getContentType m)))))

--- a/test/postal/test/message.clj
+++ b/test/postal/test/message.clj
@@ -312,3 +312,13 @@
             :subject "Test"
             :body "Test!"})]
     (is (.contains m "From: from@bar.dom"))))
+
+(deftest test-make-jmessage
+  (let [^MimeMessage m (make-jmessage
+                        {:sender "sender@bar.dom"
+                         :from "from@bar.dom"
+                         :to "baz@bar.dom"
+                         :subject "Test"
+                         :Content-Type "text/html"
+                         :body "<html><body>Test!</body></html>"})]
+    (is (= "text/html" (.getContentType m)))))


### PR DESCRIPTION
Invoking `.setText` on MimeMessage forcefully sets `Content-Type:` header to `text/plain`, overriding original value if it was there. The workaround is to set body text first then add the remaining headers.
[.setText API](https://docs.oracle.com/javaee/6/api/javax/mail/internet/MimeMessage.html#setText(java.lang.String,%20java.lang.String))
Best!
Slava