### PR TITLE
Migrate to Jakarta Mail 2.x (Angus Mail)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+3.0.0
+* Migrate from Jakarta Mail 1.6.x (com.sun.mail/jakarta.mail, javax.* namespace)
+  to Jakarta Mail 2.x via org.eclipse.angus/angus-mail. All imports move from
+  javax.mail.*/javax.activation.* to jakarta.*. BREAKING: code reaching into
+  javax.mail.* through postal must switch to jakarta.mail.*. Closes #114, #107;
+  supersedes #116 (CVE).
+
 2.0.4
 * Jakarta Mail 1.6.5
 

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :comments "Use at your own risk"}
   :deploy-repositories [["releases" :clojars]]
   :dependencies [[commons-codec "1.9"]
-                 [com.sun.mail/jakarta.mail "1.6.5"]]
+                 [org.eclipse.angus/angus-mail "2.0.5"]]
   :global-vars {*warn-on-reflection* true}
   :profiles {:dev {:dependencies []}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/src/postal/smtp.clj
+++ b/src/postal/smtp.clj
@@ -24,7 +24,7 @@
 (ns postal.smtp
   (:use [postal.message :only [make-jmessage]]
         [postal.support :only [make-props]])
-  (:import [javax.mail Transport Session]))
+  (:import [jakarta.mail Transport Session]))
 
 (defn ^:dynamic smtp-send* [^Session session ^String proto
                             {:keys [host port user pass]} msgs]
@@ -32,7 +32,7 @@
   (with-open [transport (.getTransport session proto)]
     (.connect transport host port user pass)
     (let [jmsgs (map #(make-jmessage % session) msgs)]
-      (doseq [^javax.mail.Message jmsg jmsgs]
+      (doseq [^jakarta.mail.Message jmsg jmsgs]
         (.sendMessage transport jmsg (.getAllRecipients jmsg)))
       {:code 0 :error :SUCCESS :message "messages sent"})))
 

--- a/test/postal/test/message.clj
+++ b/test/postal/test/message.clj
@@ -27,8 +27,8 @@
         [clojure.java.io :as io]
         [postal.date :only [make-date]])
   (:import [java.util Properties UUID]
-           [javax.mail Session Message$RecipientType]
-           [javax.mail.internet MimeMessage InternetAddress
+           [jakarta.mail Session Message$RecipientType]
+           [jakarta.mail.internet MimeMessage InternetAddress
             AddressException]
            [java.util.zip ZipOutputStream ZipEntry]))
 

--- a/test/postal/test/smtp.clj
+++ b/test/postal/test/smtp.clj
@@ -30,7 +30,7 @@
              :to "baz@bar.dom"
              :subject "Test"
              :body "Hello."}]
-    (binding [smtp/smtp-send* (fn [^javax.mail.Session session & _] (into {} (.getProperties session)))]
+    (binding [smtp/smtp-send* (fn [^jakarta.mail.Session session & _] (into {} (.getProperties session)))]
       (smtp/smtp-send attrs [msg]))))
 
 (defmacro is-props [input want]

--- a/test/postal/test/smtp.clj
+++ b/test/postal/test/smtp.clj
@@ -23,7 +23,9 @@
 
 (ns postal.test.smtp
   (:use [clojure.test])
-  (:require [postal.smtp :as smtp] :reload))
+  (:require [postal.smtp :as smtp] :reload)
+  (:import [jakarta.mail Session Transport]
+           [java.util Properties]))
 
 (defn props [attrs]
   (let [msg {:from "foo@bar.dom"
@@ -35,6 +37,11 @@
 
 (defmacro is-props [input want]
   `(is (= (props ~input) ~want)))
+
+(deftest test-transport-providers-resolve
+  (let [session (Session/getInstance (Properties.))]
+    (is (instance? Transport (.getTransport session "smtp")))
+    (is (instance? Transport (.getTransport session "smtps")))))
 
 (deftest t-props
   (is-props {:host "smtp.bar.dom"}


### PR DESCRIPTION
This is the jakarta migration from #114.

postal still pulls `com.sun.mail/jakarta.mail` 1.6.x, which despite the name uses the old `javax.mail.*` namespace. This swaps it for Jakarta Mail 2.x via `org.eclipse.angus/angus-mail` 2.0.5 (the Eclipse continuation of the JavaMail RI) and renames all the `javax.mail.*` / `javax.activation.*` imports over to `jakarta.*`.

That clears up a few things at once:
- **#114** — the javax/jakarta classpath mismatch (postal imported `javax.*` while the artifact and modern transitive deps resolve `jakarta.*`)
- **#107** — the JDK 9+ DataHandler/activation removal; angus-mail brings the jakarta.activation impl along transitively
- and it gets us off the 1.6.x line entirely, so it should supersede **#116** (the CVE bump)

Itʼs basically one dep swap plus a mechanical `javax.*` → `jakarta.*` rename across `message.clj`, `smtp.clj`, and the two test namespaces. angus-mail 2.0.5 pulls in `jakarta.mail-api` 2.1.5, `jakarta.activation-api` 2.1.4, and `angus-activation`, so it covers everything postal touches.

I also added a small regression test (`test-transport-providers-resolve`) that checks smtp/smtps actually resolve from a `Session` — thatʼs the thing that was breaking in #114, and itʼd fail if anyone ever dropped back to an API-only dep.

Heads up itʼs a breaking change (anything reaching into `javax.mail.*` through postal has to switch to `jakarta.mail.*`), so it lines up with the existing 3.0.0-SNAPSHOT.

Tests are green across Clojure 1.7–1.10 (25 tests, 72 assertions) on JDK 17, no reflection warnings. Left commons-codec at 1.9 to keep this focused — happy to bump it separately if you want.